### PR TITLE
Add --no-overwrite-dir when unpacking the obs archive

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /us
         $(curl -s https://api.github.com/repos/xlaaaain/obs-studio-portable-build/releases/latest | \
         jq -r ".assets[] | select(.name | test(\"ubuntu-$(lsb_release -rs).tar.bz2\$\")) | .browser_download_url") \
         -O /tmp/obs-portable/latest.tar.bz2 && \
-    tar xvf /tmp/obs-portable/latest.tar.bz2 -C /tmp/obs-portable --strip-components=1 && \
+    tar xvf /tmp/obs-portable/latest.tar.bz2 -C /tmp/obs-portable --strip-components=1 --no-overwrite-dir && \
     rm /tmp/obs-portable/latest.tar.bz2 && \
     /tmp/obs-portable/obs-container-dependencies && \
     mv /tmp/obs-portable /opt/obs-portable && \


### PR DESCRIPTION
tar throws permissions errors while unpacking the archive causing the build to fail, --no-overwrite-dir should fix this