### PR TITLE
Add DEBIAN_FRONTEND=nointeractive as global arg

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,8 @@ LABEL com.github.containers.toolbox="true" \
 
 COPY ./extra-packages /extra-packages
 
+ARG DEBIAN_FRONTEND=nointeractive
+
 RUN apt-get update && \ 
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \


### PR DESCRIPTION
buildah fails when installing obs studio portable in the container throwing this error:
```
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: 
```

adding DEBIAN_FRONTEND=nointeractive as a global arg should fix the issue.