### PR TITLE
Add --no-same-owner when unpacking archive

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,7 @@ RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /us
         $(curl -s https://api.github.com/repos/xlaaaain/obs-studio-portable-build/releases/latest | \
         jq -r ".assets[] | select(.name | test(\"ubuntu-$(lsb_release -rs).tar.bz2\$\")) | .browser_download_url") \
         -O /tmp/obs-portable/latest.tar.bz2 && \
-    tar xvf /tmp/obs-portable/latest.tar.bz2 -C /tmp/obs-portable --strip-components=1; \
+    tar xvf /tmp/obs-portable/latest.tar.bz2 -C /tmp/obs-portable --no-same-owner --strip-components=1 && \
     rm /tmp/obs-portable/latest.tar.bz2 && \
     /tmp/obs-portable/obs-container-dependencies && \
     mv /tmp/obs-portable /opt/obs-portable && \


### PR DESCRIPTION
--no-same-owner should avoid the permissions issues when unpacking the bz2 archive downloaded